### PR TITLE
Reenabling logging

### DIFF
--- a/firetweet/src/main/java/go/Go.java
+++ b/firetweet/src/main/java/go/Go.java
@@ -25,13 +25,22 @@ public final class Go {
 		// TODO(crawshaw): context.registerComponentCallbacks for runtime.GC
 
 		System.loadLibrary("gojni");
-		Go.run(ctx);
-		new Thread("GoReceive") {
-			public void run() { Seq.receive(); }
+
+		new Thread("GoMain") {
+			public void run() {
+				Go.run(ctx);
+			}
 		}.start();
+
+		Go.waitForRun();
+
+        new Thread("GoReceive") {
+            public void run() { Seq.receive(); }
+        }.start();
 	}
 
 	private static boolean running = false;
 
 	private static native void run(Context ctx);
+	private static native void waitForRun();
 }

--- a/firetweet/src/main/java/go/Seq.java
+++ b/firetweet/src/main/java/go/Seq.java
@@ -1,7 +1,3 @@
-// Copyright 2014 The Go Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style
-// license that can be found in the LICENSE file.
-
 package go;
 
 import android.util.Log;
@@ -31,7 +27,6 @@ public class Seq {
 
 	public native void log(String label);
 
-	public native boolean readBool();
 	public native byte readInt8();
 	public native short readInt16();
 	public native int readInt32();
@@ -44,7 +39,6 @@ public class Seq {
 	public String readString() { return readUTF16(); }
 	public native byte[] readByteArray();
 
-	public native void writeBool(boolean v);
 	public native void writeInt8(byte v);
 	public native void writeInt16(short v);
 	public native void writeInt32(int v);


### PR DESCRIPTION
This library update compiles flashlight against an old version of Go mobile in which logging still worked. A patch was required for building the docker image with docker 1.6.

See https://github.com/getlantern/lantern/issues/2552 and https://github.com/getlantern/lantern/pull/2583