### PR TITLE
Fix for #105

### DIFF
--- a/firetweet/src/main/java/org/getlantern/firetweet/activity/support/BrowserSignInActivity.java
+++ b/firetweet/src/main/java/org/getlantern/firetweet/activity/support/BrowserSignInActivity.java
@@ -369,7 +369,7 @@ public class BrowserSignInActivity extends BaseSupportDialogActivity implements 
             if (action == "sign_up") {
                 mActivity.loadUrl(SIGNUP_URL + data.getToken() + "&context=oauth");
             } else {
-                mActivity.loadUrl(data.getAuthorizationURL());
+                mActivity.loadUrl(data.getAuthorizationURL() + "&force_login=true");
             }
         }
 


### PR DESCRIPTION
This resolves https://github.com/getlantern/firetweet/issues/105 

After signing out, this will force the user to enter their credentials whenever they're presented with the sign-in screen webview, even if the user previously authenticated.
